### PR TITLE
Update FUNDING.yml to remove GitHub sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 buy_me_a_coffee: geanruca
+


### PR DESCRIPTION
This change removes the GitHub sponsor option and retains only the Buy Me A Coffee link. Simplifies funding options to focus on a single platform.